### PR TITLE
Use wsf message for HCI

### DIFF
--- a/HostToController.h
+++ b/HostToController.h
@@ -60,29 +60,30 @@ private:
     }
 
     void transfer(uint8_t* buffer, uint32_t length) {
-        /* link layer expects a wsf message it will take ownership of
-         * so we maintain a buffer that is a wsf msg and if we get
-         * the packet in parts we keep growing the msg copying the old
-         * into the new msg */
-
-        uint8_t *old_msg = packet;
-
-        if (!packet || (length + packet_index > packet_buffer_size)) {
-            packet_buffer_size = packet_index + length;
-            if (packet_buffer_size < MIN_WSF_ALLOC) {
-                packet_buffer_size = MIN_WSF_ALLOC;
-            }
-            packet = (uint8_t*)WsfMsgAlloc(packet_buffer_size);
-        }
-
-        if (old_msg && (old_msg != packet)) {
-            memcpy(packet, old_msg, packet_index);
-            WsfMsgFree(old_msg);
-        }
-
         // The HCI driver expect a full packet to be transfered therefore data
         // in input must be parsed and grouped in a packet.
         while (length) {
+
+            /* link layer expects a wsf message it will take ownership of
+             * so we maintain a buffer that is a wsf msg and if we get
+             * the packet in parts we keep growing the msg copying the old
+             * into the new msg */
+
+            uint8_t *old_msg = packet;
+
+            if (!packet || (length + packet_index > packet_buffer_size)) {
+                packet_buffer_size = packet_index + length;
+                if (packet_buffer_size < MIN_WSF_ALLOC) {
+                    packet_buffer_size = MIN_WSF_ALLOC;
+                }
+                packet = (uint8_t*)WsfMsgAlloc(packet_buffer_size);
+            }
+
+            if (old_msg && (old_msg != packet)) {
+                memcpy(packet, old_msg, packet_index);
+                WsfMsgFree(old_msg);
+            }
+
             switch (packet_state) {
                 case WAITING_FOR_PACKET_TYPE:
                     handle_packet_type(buffer, length);

--- a/HostToController.h
+++ b/HostToController.h
@@ -21,12 +21,15 @@
 #include "hci_defs.h"
 #include "util/CordioHCIHook.h"
 #include "drivers/RawSerial.h"
+
+#if CORDIO_ZERO_COPY_HCI
 #include "wsf_types.h"
 #include "wsf_buf.h"
 #include "wsf_msg.h"
 
 /* avoid many small allocs (and WSF doesn't have smaller buffers) */
 #define MIN_WSF_ALLOC (16)
+#endif //CORDIO_ZERO_COPY_HCI
 
 /**
  * Proxy implementation that transfer data from the host to the controller.
@@ -40,8 +43,10 @@ public:
        serial(serial),
        packet_state(WAITING_FOR_PACKET_TYPE),
        packet_type(0),
+#if CORDIO_ZERO_COPY_HCI
        packet(NULL),
        packet_buffer_size(0),
+#endif //CORDIO_ZERO_COPY_HCI
        packet_index(0),
        packet_length(0)
     { }
@@ -63,7 +68,7 @@ private:
         // The HCI driver expect a full packet to be transfered therefore data
         // in input must be parsed and grouped in a packet.
         while (length) {
-
+#if CORDIO_ZERO_COPY_HCI
             /* link layer expects a wsf message it will take ownership of
              * so we maintain a buffer that is a wsf msg and if we get
              * the packet in parts we keep growing the msg copying the old
@@ -83,6 +88,7 @@ private:
                 memcpy(packet, old_msg, packet_index);
                 WsfMsgFree(old_msg);
             }
+#endif // CORDIO_ZERO_COPY_HCI
 
             switch (packet_state) {
                 case WAITING_FOR_PACKET_TYPE:
@@ -178,9 +184,11 @@ private:
         packet_state = WAITING_FOR_PACKET_TYPE;
         packet_index = 0;
         packet_length = 0;
+#if CORDIO_ZERO_COPY_HCI
         /* link layer takes ownerhsiop of the WSF message */
         packet = NULL;
         packet_buffer_size = 0;
+#endif // CORDIO_ZERO_COPY_HCI
     }
 
     //
@@ -209,8 +217,12 @@ private:
     mbed::RawSerial& serial;
     state_t packet_state;
     uint8_t packet_type;
+#if CORDIO_ZERO_COPY_HCI
     uint8_t *packet;
     uint16_t packet_buffer_size;
+#else
+    uint8_t packet[512];
+#endif // CORDIO_ZERO_COPY_HCI
     uint16_t packet_index;
     uint16_t packet_length;
 };

--- a/main.cpp
+++ b/main.cpp
@@ -59,15 +59,18 @@ void init_wsf(ble::vendor::cordio::buf_pool_desc_t& buf_pool_desc) {
 
 int main() {
     ble::vendor::cordio::CordioHCIDriver& hci_driver = CordioHCIHook::get_driver();
-    ble::vendor::cordio::buf_pool_desc_t buf_pool_desc = hci_driver.get_buffer_pool_description();
 
+#if CORDIO_ZERO_COPY_HCI
+    ble::vendor::cordio::buf_pool_desc_t buf_pool_desc = hci_driver.get_buffer_pool_description();
     init_wsf(buf_pool_desc);
+#endif
 
     hci_driver.initialize();
 
     host_to_controller.start();
     controller_to_host.start();
 
+#if CORDIO_ZERO_COPY_HCI
     uint64_t last_update_us;
     mbed::LowPowerTimer timer;
 
@@ -102,6 +105,11 @@ int main() {
             wait_us(WSF_MS_PER_TICK * 1000 - time_spent);
         }
     }
+#else
+    while(true) {
+        rtos::Thread::wait(osWaitForever);
+    }
+#endif // CORDIO_ZERO_COPY_HCI
 
     return 0;
 }

--- a/main.cpp
+++ b/main.cpp
@@ -84,6 +84,23 @@ int main() {
         }
 
         wsfOsDispatcher();
+
+        bool sleep = false;
+        {
+            /* call needs interrupts disabled */
+            CriticalSectionLock critical_section;
+            if (wsfOsReadyToSleep()) {
+                sleep = true;
+            }
+        }
+
+        uint64_t time_spent = (uint64_t) timer.read_high_resolution_us();
+
+        /* don't bother sleeping if we're already past tick */
+        if (sleep && (WSF_MS_PER_TICK * 1000 > time_spent)) {
+            /* sleep to maintain constant tick rate */
+            wait_us(WSF_MS_PER_TICK * 1000 - time_spent);
+        }
     }
 
     return 0;

--- a/main.cpp
+++ b/main.cpp
@@ -19,6 +19,14 @@
 #include "ControllerToHost.h"
 #include "util/CordioHCIHook.h"
 #include "util/HostSerial.h"
+#include "wsf_types.h"
+#include "wsf_buf.h"
+#include "wsf_msg.h"
+#include "wsf_os.h"
+#include "wsf_buf.h"
+#include "wsf_timer.h"
+#include "hci_handler.h"
+#include "mbed.h"
 
 using ble::vendor::cordio::CordioHCIHook;
 
@@ -26,13 +34,56 @@ using ble::vendor::cordio::CordioHCIHook;
 HostToController host_to_controller(util::get_host_serial());
 ControllerToHost controller_to_host(util::get_host_serial());
 
+extern uint8_t *SystemHeapStart;
+extern uint32_t SystemHeapSize;
+
+void init_wsf(ble::vendor::cordio::buf_pool_desc_t& buf_pool_desc) {
+    // use the buffer for the WSF heap
+    SystemHeapStart = buf_pool_desc.buffer_memory;
+    SystemHeapSize = buf_pool_desc.buffer_size;
+
+    // Initialize buffers with the ones provided by the HCI driver
+    uint16_t bytes_used = WsfBufInit(
+        buf_pool_desc.pool_count,
+        (wsfBufPoolDesc_t*)buf_pool_desc.pool_description
+    );
+
+    // Raise assert if not enough memory was allocated
+    MBED_ASSERT(bytes_used != 0);
+
+    SystemHeapStart += bytes_used;
+    SystemHeapSize -= bytes_used;
+
+    WsfTimerInit();
+}
+
 int main() {
-    CordioHCIHook::get_driver().initialize();
+    ble::vendor::cordio::CordioHCIDriver& hci_driver = CordioHCIHook::get_driver();
+    ble::vendor::cordio::buf_pool_desc_t buf_pool_desc = hci_driver.get_buffer_pool_description();
+
+    init_wsf(buf_pool_desc);
+
+    hci_driver.initialize();
+
     host_to_controller.start();
     controller_to_host.start();
 
+    uint64_t last_update_us;
+    mbed::LowPowerTimer timer;
+
     while (true) {
-        rtos::Thread::wait(osWaitForever);
+        last_update_us += (uint64_t) timer.read_high_resolution_us();
+        timer.reset();
+
+        uint64_t last_update_ms = (last_update_us / 1000);
+        wsfTimerTicks_t wsf_ticks = (last_update_ms / WSF_MS_PER_TICK);
+
+        if (wsf_ticks > 0) {
+            WsfTimerUpdate(wsf_ticks);
+            last_update_us -= (last_update_ms * 1000);
+        }
+
+        wsfOsDispatcher();
     }
 
     return 0;

--- a/main.cpp
+++ b/main.cpp
@@ -19,6 +19,7 @@
 #include "ControllerToHost.h"
 #include "util/CordioHCIHook.h"
 #include "util/HostSerial.h"
+#if CORDIO_ZERO_COPY_HCI
 #include "wsf_types.h"
 #include "wsf_buf.h"
 #include "wsf_msg.h"
@@ -27,6 +28,7 @@
 #include "wsf_timer.h"
 #include "hci_handler.h"
 #include "mbed.h"
+#endif CORDIO_ZERO_COPY_HCI
 
 using ble::vendor::cordio::CordioHCIHook;
 
@@ -34,6 +36,7 @@ using ble::vendor::cordio::CordioHCIHook;
 HostToController host_to_controller(util::get_host_serial());
 ControllerToHost controller_to_host(util::get_host_serial());
 
+#if CORDIO_ZERO_COPY_HCI
 extern uint8_t *SystemHeapStart;
 extern uint32_t SystemHeapSize;
 
@@ -61,6 +64,7 @@ extern "C" void wsf_mbed_ble_signal_event(void)
 {
     // do nothing
 }
+#endif CORDIO_ZERO_COPY_HCI
 
 int main() {
     ble::vendor::cordio::CordioHCIDriver& hci_driver = CordioHCIHook::get_driver();

--- a/main.cpp
+++ b/main.cpp
@@ -57,6 +57,11 @@ void init_wsf(ble::vendor::cordio::buf_pool_desc_t& buf_pool_desc) {
     WsfTimerInit();
 }
 
+extern "C" void wsf_mbed_ble_signal_event(void)
+{
+    // do nothing
+}
+
 int main() {
     ble::vendor::cordio::CordioHCIDriver& hci_driver = CordioHCIHook::get_driver();
 


### PR DESCRIPTION
instead of a static buffer this allocates WSF msg which are handed to the link layer without copying