### PR TITLE
Update to current version of mbedos

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -19,20 +19,19 @@
 #include "ControllerToHost.h"
 #include "util/CordioHCIHook.h"
 #include "util/HostSerial.h"
-
-using ble::vendor::cordio::CordioHCIHook;
+#include "mbed_power_mgmt.h"
 
 // static initialization as these objects are large.
 HostToController host_to_controller(util::get_host_serial());
 ControllerToHost controller_to_host(util::get_host_serial());
 
 int main() {
-    CordioHCIHook::get_driver().initialize();
+    ble::CordioHCIHook::get_driver().initialize();
     host_to_controller.start();
     controller_to_host.start();
 
     while (true) {
-        rtos::Thread::wait(osWaitForever);
+        sleep();
     }
 
     return 0;

--- a/mbed-os.lib
+++ b/mbed-os.lib
@@ -1,1 +1,1 @@
-https://github.com/ARMmbed/mbed-os/#866850acc15e86cd4ac11bf4404078a49f921ddd
+https://github.com/ARMmbed/mbed-os/#890f0562dc2efb7cf76a5f010b535c2b94bce849

--- a/util/CircularBuffer.h
+++ b/util/CircularBuffer.h
@@ -18,7 +18,7 @@
 #define BLE_CLIAPP_UTIL_CIRCULARBUFFER_H
 
 #include <algorithm>
-#include "ble/ArrayView.h"
+#include "platform/Span.h"
 
 namespace util {
 
@@ -89,7 +89,7 @@ public:
         return push(src, N);
     }
 
-    CounterType push(const ble::ArrayView<const T>& src) {
+    CounterType push(const mbed::Span<const T>& src) {
         return push(src.data(), src.size());
     }
 

--- a/util/CordioHCIHook.h
+++ b/util/CordioHCIHook.h
@@ -20,11 +20,9 @@
 #include "driver/CordioHCITransportDriver.h"
 #include "driver/CordioHCIDriver.h"
 
-extern ble::vendor::cordio::CordioHCIDriver& ble_cordio_get_hci_driver();
+extern ble::CordioHCIDriver& ble_cordio_get_hci_driver();
 
 namespace ble {
-namespace vendor {
-namespace cordio {
 
 /**
  * Access to the internal state of the Cordio driver.
@@ -52,8 +50,6 @@ struct CordioHCIHook {
     }
 };
 
-} // namespace cordio
-} // namespace vendor
 } // namespace ble
 
 

--- a/util/HostSerial.h
+++ b/util/HostSerial.h
@@ -17,7 +17,7 @@
 #ifndef UTIL_HOSTSERIAL_H_
 #define UTIL_HOSTSERIAL_H_
 
-#include "drivers/RawSerial.h"
+#include "drivers/UnbufferedSerial.h"
 
 namespace util {
 
@@ -35,8 +35,8 @@ namespace util {
  * Return the host serial instance
  * @return The serial instance connected to the host.
  */
-mbed::RawSerial& get_host_serial() {
-    static mbed::RawSerial serial(USBTX, USBRX);
+mbed::UnbufferedSerial& get_host_serial() {
+    static mbed::UnbufferedSerial serial(USBTX, USBRX);
     static bool initialized = false;
 
     if (!initialized) {


### PR DESCRIPTION
Fixed refactored namespaces, bit array doesn't exist anymore so replaced with span and missing raw serial replaced with unbuffered serial.